### PR TITLE
Configure encounter action delay

### DIFF
--- a/config.ini.sample
+++ b/config.ini.sample
@@ -40,3 +40,7 @@ hash-key:               # Hash key(s) to use.
                         # Requests for high priority encounters are being preferred. If the queue is full any
                         # requests for low priority encounters are being dropped where high prio encounters are
                         # still being queued.
+
+#encounter_action_delay: 2.25   # Encounter delay between actions. Lower numbers will increase the encounters/hr per
+                                # account 2.25 is the default value. Scales linearly till about 0.5 for up to 4000 enc/hr.
+                                # This overrides a Mr. Mime setting.

--- a/config.ini.sample
+++ b/config.ini.sample
@@ -41,6 +41,6 @@ hash-key:               # Hash key(s) to use.
                         # requests for low priority encounters are being dropped where high prio encounters are
                         # still being queued.
 
-#encounter_action_delay: 2.25   # Encounter delay between actions. Lower numbers will increase the encounters/hr per
+#encounter-action-delay: 2.25   # Encounter delay between actions. Lower numbers will increase the encounters/hr per
                                 # account 2.25 is the default value. Scales linearly till about 0.5 for up to 4000 enc/hr.
                                 # This overrides a Mr. Mime setting.

--- a/pgscout/Scout.py
+++ b/pgscout/Scout.py
@@ -184,6 +184,14 @@ class Scout(POGOAccount):
         self.update_history()
         return self.parse_encounter_response(responses, job)
 
+    #Override Mr. Mime method to configure action delay in request
+    def req_encounter(self, encounter_id, spawn_point_id, latitude, longitude):
+        return self.perform_request(lambda req: req.encounter(
+            encounter_id=encounter_id,
+            spawn_point_id=spawn_point_id,
+            player_latitude=latitude,
+            player_longitude=longitude), action=cfg_get('encounter_action_delay', 2.25))
+
     def parse_encounter_response(self, responses, job):
         if not responses:
             return self.scout_error("Empty encounter response")

--- a/pgscout/config.py
+++ b/pgscout/config.py
@@ -77,6 +77,9 @@ def parse_args():
     parser.add_argument('-lpf', '--low-prio-file',
                         help='File with Pokemon names or IDs that will be treated with low priority or even dropped.')
 
+    parser.add_argument('-ead', '--encounter-action-delay', type=float, default=2.25,
+                        help='*DANGEROUS* Configure encounter action delay to before performing request. May cause faster bans/shadowbanning.  (Default 2.25)')
+
     accs = parser.add_mutually_exclusive_group(required=True)
     accs.add_argument('-pgpn', '--pgpool-num-accounts', type=int, default=0,
                       help='Use this many accounts from PGPool. --pgpool-url required.')


### PR DESCRIPTION
This PR will override the default action delay in Mr. Mime, allowing for increased encounters per hour. In testing, values around 0.5 maxes out individual scouts abilities for up to 4000 encounters/hr. Has not affected current ban rates or caused increased shadowbans. May occassionally give Niantic throttling exceptions, which cause a 5 second wait.