### PR TITLE
Account multiplier

### DIFF
--- a/pgscout/Scout.py
+++ b/pgscout/Scout.py
@@ -15,6 +15,7 @@ from pgscout.stats import inc_for_pokemon
 from pgscout.utils import calc_pokemon_level, calc_iv, distance, PRIO_NAMES
 
 log = logging.getLogger(__name__)
+scouts = []
 
 
 # Collect this many samples to determine an encounters/hour value.
@@ -34,7 +35,7 @@ ENCOUNTER_RESULTS = {
 
 
 class Scout(POGOAccount):
-    def __init__(self, auth, username, password, job_queue):
+    def __init__(self, auth, username, password, job_queue, duplicate):
         super(Scout, self).__init__(auth, username, password,
                                     hash_key_provider=cfg_get('hash_key_provider'),
                                     proxy_provider=cfg_get('proxy_provider'))
@@ -45,6 +46,7 @@ class Scout(POGOAccount):
         self.start_time = time.time()
         self.previous_encounter = None
         self.total_encounters = 0
+        self.duplicate = duplicate   # 0 = master account, 1 = duplicate account, 2 = release duplicate account from semaphore loop 
 
         # Collects the last few pauses between encounters to measure a "encounters per hour" value
         self.past_pauses = deque()
@@ -56,6 +58,8 @@ class Scout(POGOAccount):
     def run(self):
         self.log_info("Waiting for job...")
         while True:
+            if self.duplicate == 2:   # master account is banned so stop all duplicate accounts
+                break
             (prio, t, job) = self.job_queue.get()
             try:
                 if job.expired():

--- a/pgscout/ScoutGuard.py
+++ b/pgscout/ScoutGuard.py
@@ -1,19 +1,31 @@
+import time
 import logging
 import sys
 import time
 
+import pgscout.Scout
 from pgscout.Scout import Scout
-from pgscout.config import use_pgpool
+from pgscout.config import use_pgpool, cfg_get
 from pgscout.utils import load_pgpool_accounts
 
 log = logging.getLogger(__name__)
 
+def update_multiplier_accounts(username, password, acctinfo):
+    for s in range(0,len(pgscout.Scout.scouts)):
+        if (pgscout.Scout.scouts[s].acc.duplicate == 0) and (pgscout.Scout.scouts[s].acc.username == username)  and (pgscout.Scout.scouts[s].acc.password == password):  # found original account
+            log.info("Changing {} duplicate {}-{} accounts from {} to {}".format(cfg_get('pgpool_acct_multiplier')-1,s+1,s+cfg_get('pgpool_acct_multiplier'),username,acctinfo['username']))
+            for x in range(s+1, s+cfg_get('pgpool_acct_multiplier')):  
+                pgscout.Scout.scouts[x].newacc = acctinfo
+                pgscout.Scout.scouts[x].acc.duplicate = 2
+            break
 
 class ScoutGuard(object):
 
-    def __init__(self, auth, username, password, job_queue):
+    def __init__(self, auth, username, password, job_queue, duplicate, index):
         self.job_queue = job_queue
         self.active = False
+        self.index = index
+        self.newacc = {}
 
         # Set up initial account
         initial_account = {
@@ -22,34 +34,53 @@ class ScoutGuard(object):
             'password': password
         }
         if not username and use_pgpool():
-            initial_account = load_pgpool_accounts(1, reuse=True)
-        self.acc = self.init_scout(initial_account)
+                initial_account = load_pgpool_accounts(1, reuse=True)
+        self.acc = self.init_scout(initial_account, duplicate)
         self.active = True
 
-    def init_scout(self, acc_data):
-        return Scout(acc_data['auth_service'], acc_data['username'], acc_data['password'], self.job_queue)
+    def init_scout(self, acc_data, duplicate):
+        return Scout(acc_data['auth_service'], acc_data['username'], acc_data['password'], self.job_queue, duplicate)
 
     def run(self):
         while True:
             self.active = True
             self.acc.run()
             self.active = False
-            self.acc.release(reason=self.acc.last_msg)
 
+            # if duplicate wait for master account to reconfigure this account to new login info
+            if self.acc.duplicate == 1:
+                log.info("semaphore waiting, index {}".format(self.index))
+                while self.acc.duplicate == 1:
+                    time.sleep(1)
+                    pass
+                log.info("exited semaphore, index {}".format(self.index))
+
+            if self.acc.duplicate == 2:
+                log.info("duplicate index {} changing accounts from {} to {}".format(self.index,self.acc.username,self.newacc['username']))
+                self.acc.release(reason="removing multiplier account")
+                self.acc = self.init_scout(self.newacc, 1)
+                self.acc.duplicate = 1;
+                
             # Scout disabled, probably (shadow)banned.
-            if use_pgpool():
-                self.swap_account()
-            else:
-                # We don't have a replacement account, so just wait a veeeery long time.
-                time.sleep(60*60*24*1000)
-                break
+            if self.acc.duplicate == 0:
+                if use_pgpool():
+                    self.acc.release(reason=self.acc.last_msg)
+                    self.swap_account()
+                else:
+                    # We don't have a replacement account, so just wait a veeeery long time.
+                    self.acc.release(reason=self.acc.last_msg)
+                    time.sleep(60*60*24*1000)
+                    break
 
     def swap_account(self):
+        username = self.acc.username
+        password = self.acc.password
         while True:
             new_acc = load_pgpool_accounts(1)
             if new_acc:
                 log.info("Swapping bad account {} with new account {}".format(self.acc.username, new_acc['username']))
-                self.acc = self.init_scout(new_acc)
+                update_multiplier_accounts(username,password,new_acc)
+                self.acc = self.init_scout(new_acc, 0)
                 break
             log.warning("Could not request new account from PGPool. Out of accounts? Retrying in 1 minute.")
             time.sleep(60)

--- a/pgscout/config.py
+++ b/pgscout/config.py
@@ -54,6 +54,9 @@ def parse_args():
     parser.add_argument('-l', '--level', type=int, default=30,
                         help='Minimum trainer level required. Lower levels will yield an error.')
 
+    parser.add_argument('-pgpmult', '--pgpool-acct-multiplier', type=int, default=1,
+                        help='Use each account fetched from PGPOOL this number of times')
+
     parser.add_argument('-mqj', '--max-queued-jobs', type=int, default=0,
                         help='Maximum number of queued scout jobs before rejecting new jobs. 0 (default) means no restriction.')
 
@@ -153,6 +156,25 @@ def cfg_init():
         'pgpool_system_id': args.pgpool_system_id,
         'exception_on_captcha': True
     }
+
+    if args.pgpool_acct_multiplier > 1:
+        mrmime_cfg.update ({
+            'parallel_logins': False,
+            'request_retry_delay': 1,
+            'download_assets_and_items': False,
+            'full_login_flow': False,
+            'scan_delay' : 5
+        })
+
+    if args.pgpool_acct_multiplier > 1:
+        mrmime_cfg.update ({
+            'parallel_logins': False,
+            'request_retry_delay': 1,
+            'download_assets_and_items': False,
+            'full_login_flow': False,
+            'scan_delay' : 5
+        })
+
     if args.pgpool_url:
         mrmime_cfg['pgpool_url'] = args.pgpool_url
         log.info("Attaching to PGPool at {}".format(args.pgpool_url))


### PR DESCRIPTION
This uses the config file or command line options 'pgpmult' or  '--pgpool-acct-multiplier' to multiply accounts fetched from PGPool.  Default = 1 (normal operation).  If > 1, for each account pulled from PGPool via 'pgpn' configuration the account will be duplicated.  This allows a single account to be used X times which is known to have a multiplicative effort on the possible enc/hr on a single account.  Instead of 1300 enc/hr I am getting much higher using a multiplier of 6.  This PR has been in a fork testing by many people for the last few weeks. 

I know the way I turned 'scouts' into a global variable is not optimal, but it is working.  I have learned that there is a much better way to do this but have not taken the opportunity to fix since everything is working.

Here is an example with pgpn of 7 (7 pgpool accounts) and a multiplier of 6 (42 accounts total)

![image](https://user-images.githubusercontent.com/15407947/35136819-584b627c-fcab-11e7-9af1-a76e4a34e02b.png)
