### PR TITLE
Show total Enc/Hr

### DIFF
--- a/pgscout/console.py
+++ b/pgscout/console.py
@@ -86,7 +86,16 @@ def print_status(scouts, initial_display, jobs):
         elif state['display'] == 'queue':
             total_pages = print_job_queue(lines, state, jobs)
 
+        # Encounters
+        enctotal = 0
+        for scout in scouts:
+            enctotal   = enctotal   + scout.acc.encounters_per_hour if scout.active else 0.0
+
+        lines.append("")
+        lines.append("Enc/hr Total:   {:5.0f}".format(enctotal))
+
         # Footer
+        lines.append("")
         lines.append('Page {}/{}. Page number to switch pages. <enter> to '
                      'toggle log view. "p" for Pokemon stats.'
                      ' "t" to toggle accepting new requests.'.format(


### PR DESCRIPTION
This adds a total enc/hr number in the footer of the pgscout stats table.  It is great for looking at all of your accounts and knowing the total you are achieving.

You can see it at the bottom of this image
![image](https://user-images.githubusercontent.com/15407947/35136841-8e85e0ba-fcab-11e7-9597-89d11a4c8570.png)
