### PR TITLE
Fix display of long proxy addresses

### DIFF
--- a/pgscout/console.py
+++ b/pgscout/console.py
@@ -139,7 +139,9 @@ def print_scouts(lines, state, scouts):
                               map(lambda s: len(s.acc.username), scouts)))
     len_num = str(len(str(len(scouts))))
     if cfg_get('proxies'):
-        line_tmpl = u'{:' + len_num + '} | {:' + len_username + '} | {:25} | {:8} | {:4} | {:6} | {:10} | {:6} | {:6} |{:14} | {}'
+        len_proxies = str(reduce(lambda l1, l2: max(l1, l2),
+                                  map(lambda s: len(str(s.acc.proxy_url)), scouts)))
+        line_tmpl = u'{:' + len_num + '} | {:' + len_username + '} | {:' + len_proxies + '} | {:8} | {:4} | {:6} | {:10} | {:6} | {:6} | {:14} | {}'
         lines.append(
             line_tmpl.format('#', 'Scout', 'Proxy', 'Start', 'Warn', 'Active', 'Encounters', 'Enc/h', 'Errors',
                              'Last Encounter', 'Message'))


### PR DESCRIPTION
In the scouts view, when using proxies with usernames/passwords, the proxy address can exceed the width of 25 that is allocated for printing the proxy in the data screen, causing each line to get misaligned and hard to read.  This code does a check, just like already exists in this code for the usernames, to determine the maximum length of the proxy and then sets the allocated width to that instead of 25. 

Before:
![image](https://user-images.githubusercontent.com/15407947/35207027-3d8c4ee4-ff06-11e7-8fc6-6f5eaea10541.png)

After:
![image](https://user-images.githubusercontent.com/15407947/35207049-5d12ed72-ff06-11e7-82c0-9cbead868708.png)
 