### PR TITLE
Load all account threads if using PGPool

### DIFF
--- a/pgscout/ScoutGuard.py
+++ b/pgscout/ScoutGuard.py
@@ -62,4 +62,4 @@ class ScoutGuard(object):
         if self.acc:
             return self.acc.username
         else:
-            return " "              #return space so table formatter does not complain
+            return "None"              #return space so table formatter does not complain

--- a/pgscout/console.py
+++ b/pgscout/console.py
@@ -129,7 +129,12 @@ def print_scouts(lines, state, scouts):
     def scout_line(current_line, scout_guard):
         scout = scout_guard.acc
         if not scout:                           #If no scout, skip by returning None, filtered out later
-            return None
+            if cfg_get('proxies'):
+                return line_tmpl.format(current_line, "None", "", "", "", 'No', "", "", "", "",
+                                        "Waiting for new account...")
+            else:
+                return line_tmpl.format(current_line, "None", "", "", 'No', "", "", "", "",
+                                        "Waiting for new account...")
         warn = scout.get_state('warn')
         warn_str = '' if warn is None else ('Yes' if warn else 'No')
         active = 'Yes' if scout_guard.active else 'No'

--- a/pgscout/console.py
+++ b/pgscout/console.py
@@ -108,7 +108,7 @@ def print_status(scouts, initial_display, jobs):
 
         # Print lines
         os.system('cls' if os.name == 'nt' else 'clear')
-        print ('\n'.join(lines)).encode('utf-8')
+        print ('\n'.join(filter(None, lines))).encode('utf-8')  #Filter None lines from print
 
 
 def print_job_queue(lines, state, queue):
@@ -128,6 +128,8 @@ def print_job_queue(lines, state, queue):
 def print_scouts(lines, state, scouts):
     def scout_line(current_line, scout_guard):
         scout = scout_guard.acc
+        if not scout:                           #If no scout, skip by returning None, filtered out later
+            return None
         warn = scout.get_state('warn')
         warn_str = '' if warn is None else ('Yes' if warn else 'No')
         active = 'Yes' if scout_guard.active else 'No'
@@ -150,7 +152,7 @@ def print_scouts(lines, state, scouts):
                                     scout.last_msg)
 
     len_username = str(reduce(lambda l1, l2: max(l1, l2),
-                              map(lambda s: len(s.acc.username), scouts)))
+                              map(lambda s: len(s.get_account_username()), scouts)))
     len_num = str(len(str(len(scouts))))
     if cfg_get('proxies'):
         len_proxies = str(reduce(lambda l1, l2: max(l1, l2),


### PR DESCRIPTION
Load all ScoutGuard threads up to the amount configured for pgpool on startup. This will allow threads to be filled if more accounts are added to PGPool after startup.

ScoutGuard will now set Scout to `None` if no account is given and will then go into the swapaccount loop and pool PGPool every minute for a new account. Accounts that are not set will not show up in the console.

Tested in my PGScout interface and accounts were successfully started when more accounts were made available.