### PR TITLE
Prevent Total Enc/Hr display from resetting to 0 if account is inactive

### DIFF
--- a/pgscout/console.py
+++ b/pgscout/console.py
@@ -89,7 +89,7 @@ def print_status(scouts, initial_display, jobs):
         # Encounters
         enctotal = 0
         for scout in scouts:
-            enctotal   = enctotal   + scout.acc.encounters_per_hour if scout.active else 0.0
+            enctotal   = enctotal   + (scout.acc.encounters_per_hour if scout.active else 0.0)
 
         if state['display'] == 'scouts':
             lines.append("")


### PR DESCRIPTION
I've noticed my total enc/hr being stuck at 0 when there is an inactive account.  Specifically, when the last account is inactive the total will be 0.  If the inactive account is in the middle of the group, the sum will be incorrect.

I believe it is because this line
`enctotal = enctotal   + scout.acc.encounters_per_hour if scout.active else 0.0`
is being interpreted as:
`enctotal = (enctotal   + scout.acc.encounters_per_hour) if scout.active else 0.0`
and thus the total resets to 0 each time an inactive account is reached

I don't have a good way to test this but I believe this should fix it:
`enctotal   = enctotal   + (scout.acc.encounters_per_hour if scout.active else 0.0)`

Someone please review...