### PR TITLE
Prevent EOF error

### DIFF
--- a/pgscout/console.py
+++ b/pgscout/console.py
@@ -23,7 +23,10 @@ def input_processor(state):
 
     while True:
         # Wait for the user to press a key.
-        command = raw_input()
+        try:
+            command = raw_input()
+        except Exception as e:
+            command = ''
 
         if command.isdigit():
             state['page'] = int(command)


### PR DESCRIPTION
During keyboard parsing, if you press Ctrl-D in linux or Ctrl-Z in Windows it will cause an EOF Error and crash the keyboard interpreter.  Other things may do this also.  

Making this change bulletproofs the input routine