### PR TITLE
Allow usage of more L30 accounts than available from PGPool at PGScout launch

### DIFF
--- a/pgscout.py
+++ b/pgscout.py
@@ -283,7 +283,7 @@ def load_accounts(jobs):
     elif cfg_get('pgpool_url') and cfg_get('pgpool_system_id') and cfg_get('pgpool_num_accounts') > 0:
 
         acc_json = load_pgpool_accounts(cfg_get('pgpool_num_accounts'), reuse=True)
-        if isinstance(acc_json, dict):
+        if isinstance(acc_json, dict) and len(acc_json) > 0:
             acc_json = [acc_json]
 
         for i in range(0, cfg_get('pgpool_num_accounts')):

--- a/pgscout.py
+++ b/pgscout.py
@@ -286,10 +286,13 @@ def load_accounts(jobs):
         if isinstance(acc_json, dict):
             acc_json = [acc_json]
 
-        if len(acc_json) > 0:
-            log.info("Loaded {} accounts from PGPool.".format(len(acc_json)))
-            for acc in acc_json:
-                accounts.append(ScoutGuard(acc['auth_service'], acc['username'], acc['password'], jobs))
+        for i in range(0, cfg_get('pgpool_num_accounts')):
+            if i < len(acc_json):
+                accounts.append(ScoutGuard(acc_json[i]['auth_service'], acc_json[i]['username'], acc_json[i]['password'],
+                                           jobs))
+            else:
+                #We are using PGPool, load empty ScoutGuards that can be filled later
+                accounts.append(ScoutGuard(auth="", username="Waiting for account", password="", job_queue=jobs))
 
     if len(accounts) == 0:
         log.error("Could not load any accounts. Nothing to do. Exiting.")

--- a/pgscout/ScoutGuard.py
+++ b/pgscout/ScoutGuard.py
@@ -56,5 +56,7 @@ class ScoutGuard(object):
                 log.info("Swapping bad account {} with new account {}".format(self.acc.username, new_acc['username']))
                 self.acc = self.init_scout(new_acc)
                 break
+            self.acc.username = "Waiting for account"
+            self.acc.last_msg = ""
             log.warning("Could not request new account from PGPool. Out of accounts? Retrying in 1 minute.")
             time.sleep(60)

--- a/pgscout/ScoutGuard.py
+++ b/pgscout/ScoutGuard.py
@@ -31,14 +31,19 @@ class ScoutGuard(object):
 
     def run(self):
         while True:
-            self.active = True
-            self.acc.run()
-            self.active = False
-            self.acc.release(reason=self.acc.last_msg)
-
+            if self.acc.username != "Waiting for account":
+                self.active = True
+                self.acc.run()
+                self.active = False
+                self.acc.release(reason=self.acc.last_msg)
+            else:
+                self.active = False
+                self.acc.last_msg=""
+                
             # Scout disabled, probably (shadow)banned.
             if use_pgpool():
                 self.swap_account()
+                time.sleep(5)
             else:
                 # We don't have a replacement account, so just wait a veeeery long time.
                 time.sleep(60*60*24*1000)

--- a/pgscout/console.py
+++ b/pgscout/console.py
@@ -91,12 +91,14 @@ def print_status(scouts, initial_display, jobs):
 
         # Encounters
         enctotal = 0
+        active = 0
         for scout in scouts:
             enctotal   = enctotal   + (scout.acc.encounters_per_hour if scout.active else 0.0)
+            active     = active     + (1 if scout.active else 0)
 
         if state['display'] == 'scouts':
             lines.append("")
-            lines.append("Enc/hr Total:   {:5.0f}".format(enctotal))
+            lines.append("Enc/hr Total:   {:5.0f} ({} active)".format(enctotal,active))
             lines.append("")
 
         # Footer

--- a/pgscout/utils.py
+++ b/pgscout/utils.py
@@ -78,9 +78,12 @@ def load_pgpool_accounts(count, reuse=False):
         'min_level': cfg_get('level'),
         'reuse': reuse
     }
-    r = requests.get("{}/account/request".format(cfg_get('pgpool_url')), params=request)
-    return r.json()
-
+    try:
+        r = requests.get("{}/account/request".format(cfg_get('pgpool_url')), params=request)
+        return r.json()
+    except Exception as ex:
+        log.info("PGPool account fetch error: {}".format(ex))
+    return {}
 
 def distance(pos1, pos2):
     return haversine((tuple(pos1))[0:2], (tuple(pos2))[0:2])


### PR DESCRIPTION
I collaborated with @ngovil21 on this cleaner version of his PR #13.  The primary difference is elimination of extensive special handling for variables being set to None.

It allows you to ask for more PGPool accounts that you have available and it will reserve slots and keep checking every minute for available accounts.  Once available, those empty slots will turn active and go into use.  

I tested this with my database.

![image](https://user-images.githubusercontent.com/15407947/36295109-eba16070-12aa-11e8-8059-072f578e05b4.png)
